### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ d()
 
 ### dependencies
 * load deps
-* contruction deps
+* construction deps
 * runtime deps
 * AngularJS module deps (special to Angular)
 


### PR DESCRIPTION
@joeLepper, I've corrected a typographical error in the documentation of the [ng-conf](https://github.com/joeLepper/ng-conf) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
